### PR TITLE
Add multi-scale unwrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Tile manager class
 - Abstract interface to "plug-in" unwrapping algorithms
 - Unwrapping via SNAPHU, PHASS, and ICU
+- Baseline multi-scale unwrapping implementation
 
 **Changed**
 

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -12,6 +12,7 @@ API Reference
     SnaphuUnwrap
     PhassUnwrap
     ICUUnwrap
+    multiscale_unwrap
 
 **Tile Management**
 

--- a/src/tophu/__init__.py
+++ b/src/tophu/__init__.py
@@ -1,5 +1,6 @@
 from .filter import *
 from .multilook import *
+from .multiscale import *
 from .tile import *
 from .unwrap import *
 from .upsample import *

--- a/src/tophu/multiscale.py
+++ b/src/tophu/multiscale.py
@@ -1,0 +1,465 @@
+import warnings
+from typing import Optional, Tuple
+
+import numpy as np
+import scipy.signal
+from numpy.typing import ArrayLike, NDArray
+
+from .filter import bandpass_equiripple_filter
+from .multilook import multilook
+from .tile import TiledPartition
+from .unwrap import UnwrapCallback
+from .upsample import upsample_nearest
+
+__all__ = [
+    "multiscale_unwrap",
+]
+
+
+def lowpass_filter_and_multilook(
+    arr: ArrayLike,
+    downsample_factor: Tuple[int, int],
+    *,
+    shape_factor: float = 1.5,
+    overhang: float = 0.5,
+    ripple: float = 0.01,
+    attenuation: float = 40.0,
+) -> NDArray:
+    """
+    Apply an anti-aliasing pre-filter, then multilook.
+
+    Parameters
+    ----------
+    arr : array_like
+        The input data. A two-dimensional array.
+    downsample_factor : tuple of int
+        The number of looks to take along each axis of the input array.
+    shape_factor : float, optional
+        The shape factor of the filter (the ratio of the width of the combined
+        pass-band and transition band to the pass-band width). Must be greater than or
+        equal to 1. A larger shape factor results in a more gradual filter roll-off.
+        (default: 1.5)
+    overhang : float, optional
+        The fraction of the low-pass filter transition bandwidth that extends beyond the
+        Nyquist frequency of the resulting multilooked data. For example, if
+        `overhang=0`, the transition band will be entirely within the Nyquist bandwidth.
+        If `overhang=0.5`, the transition band will centered on the Nyquist frequency.
+        The value must be within the interval [0, 1]. (default: 0.5)
+    ripple : float, optional
+        The maximum allowed ripple amplitude below unity gain in the pass-band, in
+        decibels. (default: 0.01)
+    attenuation : float, optional
+        The stop-band attenuation (the difference in amplitude between the ideal gain in
+        the pass-band and the highest gain in the stop-band), in decibels. (default: 40)
+
+    Returns
+    -------
+    out : numpy.ndarray
+        The output filtered and multilooked data.
+    """
+    arr = np.asanyarray(arr)
+
+    if arr.ndim != 2:
+        raise ValueError("input array must be 2-dimensional")
+    if (overhang < 0.0) or (overhang > 1.0):
+        raise ValueError("overhang must be between 0 and 1")
+    if len(downsample_factor) != 2:
+        raise ValueError("downsample factor should be a pair of ints")
+
+    def get_filter_coeffs(n: int) -> NDArray:
+        # Get the ratio of the multilooked data sampling rate to the original data
+        # sampling rate.
+        ratio = 1.0 / n
+
+        # Compute the normalized bandwidth of the pass-band (relative to the original
+        # sampling rate), given the specified `shape_factor` and `overhang` values.
+        bandwidth = ratio / (1.0 - overhang * (shape_factor - 1.0))
+
+        # Get low pass filter coefficients. Force the filter length to be odd in order
+        # to avoid applying a phase delay.
+        return bandpass_equiripple_filter(
+            bandwidth=bandwidth,
+            shape=shape_factor,
+            ripple=ripple,
+            attenuation=attenuation,
+            force_odd_length=True,
+        )
+
+    # Get low-pass filter coefficients for each axis to be multilooked. The combined 2-D
+    # filter is the Cartesian product of the 1-D filters for each individual axis.
+    coeffs1d = map(get_filter_coeffs, downsample_factor)
+    coeffs2d = np.outer(*coeffs1d)
+
+    # Filter the input data.
+    filtered = scipy.signal.fftconvolve(arr, coeffs2d, mode="same")
+
+    # Perform spatial averaging.
+    return multilook(filtered, downsample_factor)
+
+
+def upsample_unwrapped_phase(
+    igram_hires: NDArray[np.complexfloating],
+    igram_lores: NDArray[np.floating],
+    unwrapped_phase_lores: NDArray[np.floating],
+    conncomp_lores: NDArray[np.unsignedinteger],
+) -> NDArray[np.floating]:
+    r"""
+    Upsample an unwrapped phase field resulting from coarse unwrapping.
+
+    Each pair of wrapped and unwrapped phase values are assumed to differ only by an
+    integer number of cycles of :math:`2\pi`. In that case, we can form the upsampled
+    unwrapped phase by upsampling the difference between the low-resolution unwrapped
+    and wrapped phase as an integer number of cycles and then adding it to the
+    high-resolution wrapped phase.
+
+    Parameters
+    ----------
+    igram_hires : numpy.ndarray
+        The full-resolution interferogram. A two-dimensional array.
+    igram_lores : numpy.ndarray
+        The downsampled interferogram. A two-dimensional array.
+    unwrapped_phase_lores : numpy.ndarray
+        The unwrapped phase of the low-resolution interferogram, in radians. An array
+        with the same shape as `igram_lores`.
+    conncomp_lores : numpy.ndarray
+        Connected component labels associated with the low-resolution unwrapped phase.
+        An array with the same shape as `igram_lores`. Each unique connected component
+        should be assigned a positive integer label. Pixels not belonging to any
+        connected component are considered invalid and should be labeled zero.
+
+    Returns
+    -------
+    unwrapped_phase_hires : numpy.ndarray
+        The upsampled unwrapped phase, in radians. An array with the same shape as
+        `igram_hires`.
+
+    Raises
+    ------
+    RuntimeError
+        If the wrapped and unwrapped phase values are not congruent (if the observed
+        difference between the wrapped and unwrapped phase values is not approximately
+        an integer multiple of :math:`2\pi`).
+    """
+    # Get wrapped phase from downsampled interferogram.
+    wrapped_phase_lores = np.angle(igram_lores)
+
+    # Estimate the number of cycles of phase difference between the unwrapped & wrapped
+    # arrays.
+    diff_cycles = (unwrapped_phase_lores - wrapped_phase_lores) / (2.0 * np.pi)
+    diff_cycles_int = np.round(diff_cycles).astype(np.int32)
+
+    # Get a mask of valid pixels (pixels belonging to any connected component).
+    mask = conncomp_lores != 0
+
+    # Check that the unwrapped & wrapped phase values are congruent (i.e. they differ
+    # only by an integer multiple of 2pi) to within some absolute error tolerance.
+    # Exclude invalid pixels since their phase values are not well-defined and may be
+    # subject to implementation-specific behavior of different unwrapping algorithms.
+    atol = 1.0e-3
+    if not np.allclose(diff_cycles[mask], diff_cycles_int[mask], rtol=0.0, atol=atol):
+        raise RuntimeError("wrapped and unwrapped phase values are not congruent")
+
+    # Upsample the low-res offset between the unwrapped & wrapped phase.
+    diff_cycles_hires = upsample_nearest(diff_cycles_int, out_shape=igram_hires.shape)
+
+    # Get the high-resolution wrapped phase.
+    wrapped_phase_hires = np.angle(igram_hires)
+
+    # Get the upsampled coarse unwrapped phase field by adding multiples of 2pi to the
+    # wrapped phase.
+    return wrapped_phase_hires + 2.0 * np.pi * diff_cycles_hires
+
+
+def coarse_unwrap(
+    igram: NDArray[np.complexfloating],
+    coherence: NDArray[np.floating],
+    nlooks: float,
+    unwrap: UnwrapCallback,
+    downsample_factor: Tuple[int, int],
+    *,
+    shape_factor: float = 1.5,
+    overhang: float = 0.5,
+    ripple: float = 0.01,
+    attenuation: float = 40.0,
+) -> Tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
+    """
+    Estimate coarse unwrapped phase by unwrapping a downsampled interferogram.
+
+    The input interferogram and coherence are multilooked down to lower resolution and
+    then used to form a coarse unwrapped phase estimate, which is then upsampled back to
+    the original sample spacing.
+
+    A low-pass filter is applied prior to multilooking the interferogram in order to
+    reduce aliasing effects.
+
+    Parameters
+    ----------
+    igram : numpy.ndarray
+        The input interferogram. A two-dimensional array.
+    coherence : numpy.ndarray
+        The sample coherence coefficient, with the same shape as the input
+        interferogram.
+    nlooks : float
+        The effective number of looks used to form the input interferogram and
+        coherence.
+    unwrap : UnwrapCallback
+        A callback function used to unwrap the interferogram at low resolution.
+    downsample_factor : tuple of int
+        The number of looks to take along each axis in order to form the low-resolution
+        interferogram.
+    shape_factor : float, optional
+        The shape factor of the filter (the ratio of the width of the combined
+        pass-band and transition band to the pass-band width). Must be greater than or
+        equal to 1. A larger shape factor results in a more gradual filter roll-off.
+        (default: 1.5)
+    overhang : float, optional
+        The fraction of the low-pass filter transition bandwidth that extends beyond the
+        Nyquist frequency of the resulting multilooked data. For example, if
+        `overhang=0`, the transition band will be entirely within the Nyquist bandwidth.
+        If `overhang=0.5`, the transition band will centered on the Nyquist frequency.
+        The value must be within the interval [0, 1]. (default: 0.5)
+    ripple : float, optional
+        The maximum allowed ripple amplitude below unity gain in the pass-band, in
+        decibels. (default: 0.01)
+    attenuation : float, optional
+        The stop-band attenuation (the difference in amplitude between the ideal gain in
+        the pass-band and the highest gain in the stop-band), in decibels. (default: 40)
+
+    Returns
+    -------
+    unwrapped_phase : numpy.ndarray
+        The unwrapped phase, in radians. An array with the same shape as the input
+        interferogram.
+    conncomp : numpy.ndarray
+        An array of connected component labels, with the same shape as the unwrapped
+        phase.
+    """
+    # Get low-resolution interferogram & coherence data by multilooking. Low-pass filter
+    # the interferogram prior to multilooking to avoid aliasing. Multilooking may raise
+    # warnings if the number of looks is even-valued or the input array shape is not a
+    # multiple of the number of looks, both of which we can safely ignore.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        igram_lores = lowpass_filter_and_multilook(
+            igram,
+            downsample_factor,
+            shape_factor=shape_factor,
+            overhang=overhang,
+            ripple=ripple,
+            attenuation=attenuation,
+        )
+        coherence_lores = multilook(coherence, downsample_factor)
+
+    # Calculate the number of looks in the downsampled data.
+    # XXX This isn't quite correct if the input data is single-look oversampled data
+    # (`nlooks` should be 1 in that case, but `nlooks_lores` should ideally take into
+    # account the spatial correlation of the signal that will reduce the effective
+    # number of looks).
+    nlooks_lores = nlooks * np.prod(downsample_factor)
+
+    # Unwrap the downsampled data.
+    unwrapped_phase, conncomp = unwrap(
+        igram=igram_lores,
+        corrcoef=coherence_lores,
+        nlooks=nlooks_lores,
+    )
+
+    # Upsample unwrapped phase & connected component labels.
+    unwrapped_phase_hires = upsample_unwrapped_phase(
+        igram_hires=igram,
+        igram_lores=igram_lores,
+        unwrapped_phase_lores=unwrapped_phase,
+        conncomp_lores=conncomp,
+    )
+    conncomp_hires = upsample_nearest(conncomp, out_shape=igram.shape)
+
+    return unwrapped_phase_hires, conncomp_hires
+
+
+def adjust_conncomp_offset_cycles(
+    unwrapped_phase_hires: NDArray[np.floating],
+    conncomp_hires: NDArray[np.unsignedinteger],
+    unwrapped_phase_lores: NDArray[np.floating],
+    conncomp_lores: NDArray[np.unsignedinteger],
+) -> None:
+    r"""
+    Remove phase cycle offsets from the high-resolution unwrapped phase.
+
+    Attempt to correct for phase discontinuities in the unwrapped phase, such as those
+    due to absolute phase ambiguities between independently unwrapped tiles, using a
+    coarse estimate of the unwrapped phase as a reference. The high-resolution unwrapped
+    phase is augmented by adding or subtracting cycles of :math:2\pi` to each connected
+    component in order to minimize the mean discrepancy between the high-resolution and
+    low-resolution phase values.
+
+    The `unwrapped_phase_hires` array is modified in-place.
+
+    Parameters
+    ----------
+    unwrapped_phase_hires : numpy.ndarray
+        The high-resolution unwrapped phase, in radians.
+    conncomp_hires : numpy.ndarray
+        Connected component labels associated with the high-resolution unwrapped phase.
+        An array with the same shape as `unwrapped_phase_hires`.
+    unwrapped_phase_lores : numpy.ndarray
+        A coarse estimate of the unwrapped phase, in radians. An array with the same
+        shape as `unwrapped_phase_hires`.
+    conncomp_lores : numpy.ndarray
+        Connected component labels associated with the low-resolution unwrapped phase.
+        An array with the same shape as `unwrapped phase_lores`.
+    """
+    # Get unique, non-zero connected component labels in the high-resolution data.
+    unique_labels = set(np.unique(conncomp_hires))
+    unique_nonzero_labels = unique_labels - {0}
+
+    # For each connected component, determine the phase cycle offset between the
+    # low-resolution and high-resolution unwrapped phase by computing the mean phase
+    # difference, rounded to the nearest integer number of 2pi cycles.
+    for label in unique_nonzero_labels:
+        # Create a mask of pixels belonging to the current connected component in the
+        # high-res data.
+        conncomp_mask = conncomp_hires == label
+
+        # Create a mask of pixels that are within the current connected component and
+        # were valid (i.e. belonged to any connected component) in the low-res data.
+        valid_mask = conncomp_mask & (conncomp_lores != 0)
+
+        if np.any(valid_mask):
+            # Compute the number of 2pi cycles that should be removed from the
+            # high-resolution phase in order to minimize the mean difference between the
+            # high-res and low-res phase.
+            avg_offset = np.mean(
+                unwrapped_phase_hires[valid_mask] - unwrapped_phase_lores[valid_mask]
+            )
+            avg_offset_cycles = np.round(avg_offset / (2.0 * np.pi))
+
+            # Adjust the high-resolution phase in-place by subtracting a number of 2pi
+            # phase cycles.
+            unwrapped_phase_hires[conncomp_mask] -= 2.0 * np.pi * avg_offset_cycles
+
+
+def multiscale_unwrap(
+    igram: NDArray[np.complexfloating],
+    coherence: NDArray[np.floating],
+    nlooks: float,
+    unwrap: UnwrapCallback,
+    downsample_factor: Tuple[int, int],
+    ntiles: Tuple[int, int],
+    tile_overlap: Optional[Tuple[int, int]] = None,
+    *,
+    shape_factor: float = 1.5,
+    overhang: float = 0.5,
+    ripple: float = 0.01,
+    attenuation: float = 40.0,
+) -> Tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
+    """
+    Perform 2-D phase unwrapping using a multi-resolution approach.
+
+    The input interferogram is broken up into smaller tiles, which are then unwrapped
+    independently. In order to avoid phase discontinuities between tiles, additional
+    phase cycles are added or subtracted within each tile in order to minimize the
+    discrepancy with a coarse unwrapped phase estimate formed by multilooking the
+    original interferogram.
+
+    Parameters
+    ----------
+    igram : numpy.ndarray
+        The input interferogram. A two-dimensional array.
+    coherence : numpy.ndarray
+        The sample coherence coefficient, with the same shape as the input
+        interferogram.
+    nlooks : float
+        The effective number of looks used to form the input interferogram and
+        coherence.
+    unwrap : UnwrapCallback
+        A callback function used to unwrap the low-resolution interferogram and each
+        high-resolution interferogram tile.
+    downsample_factor : tuple of int
+        The number of looks to take along each axis in order to form the low-resolution
+        interferogram.
+    ntiles : tuple of int
+        The number of tiles along each axis. A pair of integers specifying the shape of
+        the grid of tiles to partition the input interferogram into.
+    tile_overlap : tuple of int or None, optional
+        The overlap between adjacent tiles along each array axis, in samples.
+        (default: None)
+    shape_factor : float, optional
+        The shape factor of the anti-aliasing low-pass filter applied prior to
+        multilooking (the ratio of the width of the combined pass-band and transition
+        band to the pass-band width). A larger shape factor results in a more gradual
+        filter roll-off. (default: 1.5)
+    overhang : float, optional
+        The fraction of the low-pass filter transition bandwidth that extends beyond the
+        Nyquist frequency of the resulting multilooked data. For example, if
+        `overhang=0`, the transition band will be entirely within the Nyquist bandwidth.
+        If `overhang=0.5`, the transition band will centered on the Nyquist frequency.
+        The value must be within the interval [0, 1]. (default: 0.5)
+    ripple : float, optional
+        The maximum allowed ripple amplitude below unity gain in the pass-band of the
+        pre-filter, in decibels. (default: 0.01)
+    attenuation : float, optional
+        The stop-band attenuation of the pre-filter (the difference in amplitude between
+        the ideal gain in the pass-band and the highest gain in the stop-band), in
+        decibels. (default: 40)
+
+    Returns
+    -------
+    unwrapped_phase : numpy.ndarray
+        The unwrapped phase, in radians. An array with the same shape as the input
+        interferogram.
+    conncomp : numpy.ndarray
+        An array of connected component labels, with the same shape as the unwrapped
+        phase.
+    """
+    if igram.shape != coherence.shape:
+        raise ValueError(
+            "shape mismatch: interferogram and coherence arrays must have the same"
+            " shape"
+        )
+    if nlooks < 1.0:
+        raise ValueError("effective number of looks must be >= 1")
+    if any(map(lambda d: d < 1, downsample_factor)):
+        raise ValueError("downsample factor must be >= 1")
+    if any(map(lambda n: n < 1, ntiles)):
+        raise ValueError("number of tiles must be >= 1")
+
+    # Get a coarse estimate of the unwrapped phase using a low-resolution copy of the
+    # interferogram.
+    unwrapped_phase_lores, conncomp_lores = coarse_unwrap(
+        igram=igram,
+        coherence=coherence,
+        nlooks=nlooks,
+        unwrap=unwrap,
+        downsample_factor=downsample_factor,
+        shape_factor=shape_factor,
+        overhang=overhang,
+        ripple=ripple,
+        attenuation=attenuation,
+    )
+
+    # Init output unwrapped phase and connected component labels.
+    unwrapped_phase = np.zeros_like(igram, dtype=np.float32)
+    conncomp = np.zeros_like(igram, dtype=np.uint32)
+
+    # Partition the input interferogram into (possibly overlapping) tiles.
+    tiles = TiledPartition(igram.shape, ntiles=ntiles, overlap=tile_overlap)
+
+    for tile in tiles:
+        # Unwrap each tile independently.
+        unwrapped_phase[tile], conncomp[tile] = unwrap(
+            igram=igram[tile],
+            corrcoef=coherence[tile],
+            nlooks=nlooks,
+        )
+
+        # Add or subtract multiples of 2pi to each connected component to minimize the
+        # mean discrepancy between the high-res and low-res unwrapped phase (in order to
+        # correct for phase discontinuities between adjacent tiles).
+        adjust_conncomp_offset_cycles(
+            unwrapped_phase[tile],
+            conncomp[tile],
+            unwrapped_phase_lores[tile],
+            conncomp_lores[tile],
+        )
+
+    return unwrapped_phase, conncomp

--- a/test/test_multiscale.py
+++ b/test/test_multiscale.py
@@ -1,0 +1,270 @@
+from typing import Tuple
+
+import numpy as np
+import pytest
+from numpy.typing import ArrayLike, NDArray
+
+import tophu
+
+from .simulate import simulate_phase_noise, simulate_terrain
+
+
+def dummy_igram_and_coherence(
+    length: int = 128,
+    width: int = 128,
+) -> Tuple[NDArray[np.complexfloating], NDArray[np.floating]]:
+    """
+    Return dummy interferogram and coherence arrays (for tests that don't care about
+    their values).
+    """
+    length, width = 128, 128
+    igram = np.zeros((length, width), dtype=np.complex64)
+    coherence = np.ones((length, width), dtype=np.float32)
+    return igram, coherence
+
+
+def round_to_nearest(n: ArrayLike, base: ArrayLike) -> NDArray:
+    """Round to the nearest multiple of `base`."""
+    n = np.asanyarray(n)
+    base = np.asanyarray(base)
+    return base * round(n / base)
+
+
+def frac_nonzero(arr: ArrayLike) -> float:
+    """Compute the fraction of pixels in an array that have nonzero values."""
+    return np.count_nonzero(arr) / np.size(arr)
+
+
+def jaccard_similarity(a, b):
+    """
+    Compute the Jaccard similarity coefficient (intersect-over-union) of two boolean
+    arrays.
+
+    Parameters
+    ----------
+    a, b : array_like
+        The input binary masks.
+
+    Returns
+    -------
+    J : float
+        The Jaccard similarity coefficient of the two inputs.
+    """
+    return np.sum(a & b) / np.sum(a | b)
+
+
+class TestMultiScaleUnwrap:
+    # XXX Currently we're not testing with PHASS due to an issue where the unwrapped
+    # phase seems to not be congruent with the wrapped phase, which causes the
+    # processing to fail. This needs to be further investigated.
+    @pytest.mark.parametrize("length,width", [(1023, 1023), (1024, 1024)])
+    @pytest.mark.parametrize("unwrap", [tophu.ICUUnwrap(), tophu.SnaphuUnwrap()])
+    def test_multiscale_unwrap_phase(self, length, width, unwrap):
+        # Radar sensor/geometry parameters.
+        near_range = 900_000.0
+        range_spacing = 6.25
+        az_spacing = 6.0
+        range_res = 7.5
+        az_res = 6.6
+        bperp = 500.0
+        wvl = 0.24
+        inc_angle = np.deg2rad(37.0)
+
+        # Simulate random topography.
+        z = simulate_terrain(length, width, scale=2000.0, smoothness=0.9, seed=123)
+
+        # Get multilooked sample spacing.
+        nlooks_range = 5
+        nlooks_az = 5
+        dr = nlooks_range * range_spacing
+        da = nlooks_az * az_spacing
+
+        # Simulate topographic phase term.
+        r = near_range + dr * np.arange(width)
+        phase = -4.0 * np.pi / wvl * bperp / r[None, :] * np.sin(inc_angle) * z
+
+        # Add a diagonal linear phase gradient such that, if we were to naively unwrap
+        # by tiles without applying a post-processing correction, each tile will have
+        # some relative phase offset with respect to the other tiles, resulting in
+        # discontinuities at the borders between tiles.
+        x = np.linspace(0.0, 50.0, width, dtype=np.float32)
+        y = np.linspace(0.0, 50.0, length, dtype=np.float32)
+        phase += x + y[:, None]
+
+        # Form simulated interferogram & coherence with no noise.
+        igram = np.exp(1j * phase)
+        coherence = np.ones((length, width), dtype=np.float32)
+
+        # Get effective number of looks.
+        nlooks = dr * da / (range_res * az_res)
+
+        # Unwrap using the multi-resolution approach.
+        unw, conncomp = tophu.multiscale_unwrap(
+            igram=igram,
+            coherence=coherence,
+            nlooks=nlooks,
+            unwrap=unwrap,
+            downsample_factor=(3, 3),
+            ntiles=(2, 2),
+        )
+
+        # Get a mask of valid pixels (pixels that were assigned to some connected
+        # component).
+        mask = conncomp != 0
+
+        # Check the unwrapped phase. The unwrapped phase and absolute (true) phase
+        # should differ only by a constant integer multiple of 2pi. The test metric is
+        # the fraction of correctly unwrapped pixels, i.e. pixels where the unwrapped
+        # phase and absolute phase agree up to some constant number of cycles, excluding
+        # masked pixels.
+        phasediff = (phase - unw)[mask]
+        offset = round_to_nearest(np.mean(phasediff), 2.0 * np.pi)
+        good_pixels = np.isclose(unw[mask] + offset, phase[mask], rtol=1e-5, atol=1e-5)
+        assert frac_nonzero(good_pixels) > 0.999
+
+        # Check the connected component labels. There should be a single connected
+        # component (with label 1) which contains most pixels. Any remaining pixels
+        # should be masked out (with label 0).
+        unique_labels = set(np.unique(conncomp[mask]))
+        assert unique_labels == {1}
+        assert frac_nonzero(conncomp) > 0.999
+
+    @pytest.mark.parametrize("unwrap", [tophu.ICUUnwrap(), tophu.SnaphuUnwrap()])
+    def test_multiscale_unwrap_phase_conncomps(self, unwrap):
+        length, width = 512, 512
+
+        # Radar sensor/geometry parameters.
+        near_range = 900_000.0
+        range_spacing = 6.25
+        az_spacing = 6.0
+        range_res = 7.5
+        az_res = 6.6
+        bperp = 500.0
+        wvl = 0.24
+        inc_angle = np.deg2rad(37.0)
+
+        # Simulate random topography.
+        z = simulate_terrain(length, width, scale=2000.0, smoothness=0.9, seed=123)
+
+        # Get multilooked sample spacing.
+        nlooks_range = 5
+        nlooks_az = 5
+        dr = nlooks_range * range_spacing
+        da = nlooks_az * az_spacing
+
+        # Simulate topographic phase term.
+        r = near_range + dr * np.arange(width)
+        phase = -4.0 * np.pi / wvl * bperp / r[None, :] * np.sin(inc_angle) * z
+
+        # Add a diagonal linear phase gradient such that, if we were to naively unwrap
+        # by tiles without applying a post-processing correction, each tile will have
+        # some relative phase offset with respect to the other tiles, resulting in
+        # discontinuities at the borders between tiles.
+        x = np.linspace(0.0, 50.0, width, dtype=np.float32)
+        y = np.linspace(0.0, 50.0, length, dtype=np.float32)
+        phase += x + y[:, None]
+
+        # Form two islands of high coherence that span multiple tiles, separated by low
+        # coherence pixels.
+        conncomp_mask_1 = np.full((length, width), fill_value=True, dtype=np.bool_)
+        conncomp_mask_1[64:-64, 64:-64] = False
+
+        conncomp_mask_2 = np.full((length, width), fill_value=False, dtype=np.bool_)
+        conncomp_mask_2[192:-192, 192:-192] = True
+
+        coherence = np.ones((length, width), dtype=np.float32)
+        coherence[~conncomp_mask_1 & ~conncomp_mask_2] = 0.01
+
+        # Get effective number of looks.
+        nlooks = dr * da / (range_res * az_res)
+
+        # Add phase noise.
+        phase += simulate_phase_noise(coherence, nlooks)
+
+        # Form simulated interferogram.
+        igram = np.exp(1j * phase)
+
+        # Unwrap using the multi-resolution approach.
+        unw, conncomp = tophu.multiscale_unwrap(
+            igram=igram,
+            coherence=coherence,
+            nlooks=nlooks,
+            unwrap=unwrap,
+            downsample_factor=(3, 3),
+            ntiles=(2, 2),
+        )
+
+        # Check the unwrapped phase within each expected connected component. The
+        # unwrapped phase and absolute (true) phase should differ only by a constant
+        # integer multiple of 2pi. The test metric is the fraction of correctly
+        # unwrapped pixels, i.e. pixels where the unwrapped phase and absolute phase
+        # agree up to some constant number of cycles, excluding masked pixels.
+        for mask in [conncomp_mask_1, conncomp_mask_2]:
+            phasediff = (phase - unw)[mask]
+            offset = round_to_nearest(np.mean(phasediff), 2.0 * np.pi)
+            good_pixels = np.isclose(
+                unw[mask] + offset, phase[mask], rtol=1e-5, atol=1e-5
+            )
+            assert frac_nonzero(good_pixels) > 0.999
+
+        # Check the connected component labels.
+        # XXX We haven't yet implemented a correction for discrepancies between labels
+        # from different tiles. For now, just check the mask of all valid pixels,
+        # regardless of their label.
+        mask = conncomp != 0
+        expected_mask = conncomp_mask_1 | conncomp_mask_2
+        assert jaccard_similarity(mask, expected_mask) > 0.99
+
+    def test_shape_mismatch(self):
+        length, width = 128, 128
+        igram = np.zeros((length, width), dtype=np.complex64)
+        coherence = np.ones((length + 1, width + 1), dtype=np.float32)
+        errmsg = (
+            "shape mismatch: interferogram and coherence arrays must have the same"
+            " shape"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            tophu.multiscale_unwrap(
+                igram,
+                coherence,
+                nlooks=1.0,
+                unwrap=tophu.ICUUnwrap(),
+                downsample_factor=(3, 3),
+                ntiles=(2, 2),
+            )
+
+    def test_bad_nlooks(self):
+        igram, coherence = dummy_igram_and_coherence()
+        with pytest.raises(ValueError, match="effective number of looks must be >= 1"):
+            tophu.multiscale_unwrap(
+                igram,
+                coherence,
+                nlooks=0.0,
+                unwrap=tophu.ICUUnwrap(),
+                downsample_factor=(3, 3),
+                ntiles=(2, 2),
+            )
+
+    def test_bad_downsample_factor(self):
+        igram, coherence = dummy_igram_and_coherence()
+        with pytest.raises(ValueError, match="downsample factor must be >= 1"):
+            tophu.multiscale_unwrap(
+                igram,
+                coherence,
+                nlooks=1.0,
+                unwrap=tophu.ICUUnwrap(),
+                downsample_factor=(0, 0),
+                ntiles=(2, 2),
+            )
+
+    def test_bad_ntiles(self):
+        igram, coherence = dummy_igram_and_coherence()
+        with pytest.raises(ValueError, match="number of tiles must be >= 1"):
+            tophu.multiscale_unwrap(
+                igram,
+                coherence,
+                nlooks=1.0,
+                unwrap=tophu.ICUUnwrap(),
+                downsample_factor=(3, 3),
+                ntiles=(0, 0),
+            )


### PR DESCRIPTION
This PR adds basic multi-scale unwrapping functionality.

### API updates

A new public function `multiscale_unwrap()` is added, which estimates unwrapped phase from an interferogram using a multi-resolution unwrapping strategy.

First, the interferogram is multilooked down to lower resolution and unwrapped to form a coarse estimate of the unwrapped phase. Then, the original interferogram is broken down into smaller tiles, which are each unwrapped independently. In order to mitigate phase discontinuities at tile boundaries, the phase values within each tile are then augmented by some number of phase cycles, using the coarse unwrapped estimate as a reference for the absolute phase. Specifically, the phase within each connected component is adjusted by a number of phase cycles in order to minimize its mean absolute difference with the low-resolution unwrapped phase estimate.

### Test cases

Two simple test cases have been added to exercise the new functionality.

The first test case simulates a noise-less interferogram with a roughly diagonal phase gradient such that, if the interferogram were unwrapped by tiles without any post-processing correction, there would be a significant phase offset between each tile. It then checks that the resulting unwrapped phase field differs from the simulated absolute phase only by a fixed integer number of phase cycles, with no phase discontinuities between tiles.

The figure below demonstrates the test data and compares the result of the multi-scale unwrapping approach with a naive tile-based unwrapping approach with no secondary unwrapping. The interferogram was partitioned into a 2x2 grid of tiles for unwrapping. In the simple tile-based unwrapping result, large phase discontinuities are visible along the tile boundaries.

![fig1](https://user-images.githubusercontent.com/12984092/184758098-eadfc270-9ee7-4b81-b513-7e6db44c6394.png)

The second test case is similar to the first, but increases the complexity by partitioning the interferogram into several isolated regions of high-coherence pixels, each of which span multiple tiles and are separated by noisy pixels. The test checks the unwrapped phase values within each high-coherence region independently. 

The figure below shows the test dataset unwrapped using SNAPHU. Note that the connected component labels show inconsistencies and mislabelings between tiles. This issue will be addressed in subsequent work.

![fig2](https://user-images.githubusercontent.com/12984092/184758725-393150f0-dc36-43da-ac6d-aa9a76bd0109.png)

### Known limitations

The following known issues will be addressed in subsequent PRs:

* Multi-scale unwrapping using PHASS is currently not working (ICU & SNAPHU are working and both are exercised by the test suite). The current behavior is that the code raises an exception saying that the unwrapped phase values are not congruent with the input wrapped phase.

   This seems to be due to a small number of pixels in the unwrapped phase that are filled with a large negative value (`-10000`) that is inconsistent with the surrounding phase values. The pixels are labeled as belonging to a connected component so they should be valid.

   I'll need to investigate this further.

* Currently, each tile is unwrapped in serial, one-by-one, but in the future we could unwrap them in parallel (perhaps using `dask`).

* As noted above, connected component labels from different tiles are inconsistent. I plan to address this in my next PR. For now, only the output unwrapped phase is reliable.