### PR TITLE
Cleanup BibTex tags

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -1,7 +1,7 @@
 %comment{This file was created with betterbib v4.3.8.}
 
 
-@article{chen:2001,
+@article{chen2001,
  author = {Chen, Curtis W. and Zebker, Howard A.},
  title = {Two-dimensional phase unwrapping with use of statistical models for cost functions in nonlinear optimization},
  journal = {Journal of the Optical Society of America A},
@@ -17,7 +17,7 @@
  source = {Crossref},
 }
 
-@inproceedings{kaiser:1974,
+@inproceedings{kaiser1974,
  author = {Kaiser, James F.},
  title = {Nonrecursive Digital Filter Design Using the I0-Sinh Window Function.},
  booktitle = {Proceedings of the 1974 IEEE International Symposium on Circuits and Systems},
@@ -27,7 +27,7 @@
  month = apr,
 }
 
-@article{lee:1994,
+@article{lee1994,
  author = {Lee, Jong-Sen and Hoppel, K.W. and Mango, S.A. and Miller, A.R.},
  title = {Intensity and phase statistics of multilook polarimetric and interferometric {SAR} imagery},
  journal = {IEEE Transactions on Geoscience and Remote Sensing},
@@ -42,7 +42,7 @@
  source = {Crossref},
 }
 
-@article{mcclellan:1973,
+@article{mcclellan1973,
  author = {McClellan, J. and Parks, T.},
  title = {A unified approach to the design of optimum {FIR} linear-phase digital filters},
  journal = {IEEE Transactions on Circuit Theory},
@@ -58,7 +58,7 @@
  source = {Crossref},
 }
 
-@article{miller:1986,
+@article{miller1986,
  author = {Miller, Gavin S P},
  title = {The definition and rendering of terrain maps},
  journal = {ACM SIGGRAPH Computer Graphics},
@@ -75,7 +75,7 @@
  source = {Crossref},
 }
 
-@article{rodriguez:1992,
+@article{rodriguez1992,
  author = {Rodriguez, E. and Martin, J.M.},
  title = {Theory and design of interferometric synthetic aperture radars},
  journal = {IEE Proceedings F Radar and Signal Processing},

--- a/src/tophu/filter.py
+++ b/src/tophu/filter.py
@@ -13,7 +13,7 @@ def equiripple_filter_order_kaiser(ptol: float, stol: float, width: float) -> in
 
     Predicts the order of a finite impulse response (FIR) digital filter obtained from
     the optimal equiripple approximation method using Kaiser's formula\
-    :footcite:p:`kaiser:1974`.
+    :footcite:p:`kaiser1974`.
 
     Evaluates
 
@@ -66,7 +66,7 @@ def bandpass_equiripple_filter(
 
     Form a linear-phase finite impulse response (FIR) discrete-time digital filter wth
     desired passband, stopband, and attenuation characteristics using the
-    Parks-McClellan algorithm\ :footcite:p:`mcclellan:1973`. The algorithm produces a
+    Parks-McClellan algorithm\ :footcite:p:`mcclellan1973`. The algorithm produces a
     filter that is optimal in the sense that it minimizes the maximum weighted deviation
     from the ideal frequency response in the passband and stopband.
 

--- a/src/tophu/multiscale.py
+++ b/src/tophu/multiscale.py
@@ -31,7 +31,7 @@ def lowpass_filter_and_multilook(
     Apply an anti-aliasing pre-filter, then multilook.
 
     The input array is filtered by applying a low-pass filter constructed using the
-    optimal equiripple method\ :footcite:p:`mcclellan:1973` and then multilooked to
+    optimal equiripple method\ :footcite:p:`mcclellan1973` and then multilooked to
     produce the downsampled output. However, if the number of looks along any axis is 1,
     no filtering will be applied along that axis of the array.
 

--- a/src/tophu/unwrap.py
+++ b/src/tophu/unwrap.py
@@ -63,7 +63,7 @@ class SnaphuUnwrap(UnwrapCallback):
     r"""
     Callback functor for unwrapping using SNAPHU.
 
-    Performs unwrapping using the SNAPHU algorithm\ :footcite:p:`chen:2001`.
+    Performs unwrapping using the SNAPHU algorithm\ :footcite:p:`chen2001`.
     """
 
     cost: str

--- a/test/simulate.py
+++ b/test/simulate.py
@@ -22,9 +22,9 @@ def simulate_phase_noise(
 
     The resulting samples are zero-mean Gaussian distributed, with variance equal to the
     Cramer-Rao bound of the Maximum Likelihood Estimator for the interferometric
-    phase\ :footcite:p:`rodriguez:1992`. This simple approximation is most accurate for
+    phase\ :footcite:p:`rodriguez1992`. This simple approximation is most accurate for
     high coherence and large number of looks. The true phase difference distribution is
-    more complicated\ :footcite:p:`lee:1994`.
+    more complicated\ :footcite:p:`lee1994`.
 
     Parameters
     ----------
@@ -65,7 +65,7 @@ def simulate_terrain(
     r"""Simulate topography using the Diamond-Square algorithm.
 
     Generate a 2-D fractal height map using the Diamond-Square algorithm\
-    :footcite:p:`miller:1986`.
+    :footcite:p:`miller1986`.
 
     Parameters
     ----------


### PR DESCRIPTION
Simplify the naming convention for BibTex tags. The old style was a little busy and harder to read.