### PR TITLE
Migrate CI to use setup-micromamba action

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
           - label: Latest
             spec: ""
           - label: Minimum
-            spec: |
+            spec: >-
               dask=2022.05.1
               h5py=3
               isce3=0.12
@@ -35,12 +35,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup environment
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: requirements.txt
           environment-name: tophu
-          extra-specs: ${{ matrix.deps.spec }}
-          channels: conda-forge
+          create-args: ${{ matrix.deps.spec }}
+          condarc: |
+            channels:
+              - conda-forge
+              - nodefaults
       - name: Install
         run: |
           pip install --no-deps .


### PR DESCRIPTION
The previous workflow used the `provision-with-micromamba` action[^1], which has been deprecated and is superceded by `setup-micromamba`[^2], which has similar behavior for our purposes, but a slightly different interface for configuration.

Thanks to @scottstanie for noticing this and pointing it out in https://github.com/opera-adt/dolphin/issues/113

[^1]: https://github.com/mamba-org/provision-with-micromamba
[^2]: https://github.com/mamba-org/setup-micromamba