### PR TITLE
Update README to link to new LICENSE files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ All rights reserved.
 
 ## License
 
-This software is licensed under your choice of BSD-3-Clause or Apache-2.0 licenses. See
-the accompanying [LICENSE](LICENSE) file for further details.
+This software is licensed under your choice of BSD-3-Clause or Apache-2.0 licenses. The
+exact terms of each license can be found in the accompanying
+[LICENSE-BSD-3-Clause](LICENSE-BSD-3-Clause) and
+[LICENSE-Apache-2.0](LICENSE-Apache-2.0) files, respectively.
 
 SPDX-License-Identifier: BSD-3-Clause OR Apache-2.0


### PR DESCRIPTION
Fix the "License" section of the README.md file following #15 to remove the broken link to the old LICENSE file and correctly link to the new files