### PR TITLE
Bump versions of deprecated actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup environment
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -52,4 +52,4 @@ jobs:
           micromamba install -f test/requirements.txt -c conda-forge
           pytest --cov-report=xml
       - name: Coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Update to the latest versions of `actions/checkout` and `codecov/codecov-action`. The older actions were emitting warning messages due to reliance on a deprecated version of node.

It's supposedly possible to teach Dependabot to [automatically keep these versions updated for you](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot). Will look into implementing this in a subsequent PR.