### PR TITLE
Modernize type annotations

### DIFF
--- a/src/tophu/multilook.py
+++ b/src/tophu/multilook.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import warnings
-from typing import Iterable, SupportsInt, Tuple, Union, cast
+from collections.abc import Iterable
+from typing import cast
 
 import dask.array as da
 import numpy as np
@@ -11,10 +14,7 @@ __all__ = [
 ]
 
 
-IntOrInts = Union[SupportsInt, Iterable[SupportsInt]]
-
-
-def multilook(arr: da.Array, nlooks: IntOrInts) -> da.Array:
+def multilook(arr: da.Array, nlooks: int | Iterable[int]) -> da.Array:
     """
     Multilook an array by simple averaging.
 
@@ -53,7 +53,7 @@ def multilook(arr: da.Array, nlooks: IntOrInts) -> da.Array:
             )
 
     # Convince static type checkers that `nlooks` is a tuple of ints now.
-    nlooks = cast(Tuple[int, ...], nlooks)
+    nlooks = cast(tuple[int, ...], nlooks)
 
     # The number of looks must be at least 1 and at most the size of the input array
     # along the corresponding axis.

--- a/src/tophu/multilook.py
+++ b/src/tophu/multilook.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable
-from typing import cast
+from typing import Tuple, cast
 
 import dask.array as da
 import numpy as np
@@ -53,7 +53,7 @@ def multilook(arr: da.Array, nlooks: int | Iterable[int]) -> da.Array:
             )
 
     # Convince static type checkers that `nlooks` is a tuple of ints now.
-    nlooks = cast(tuple[int, ...], nlooks)
+    nlooks = cast(Tuple[int, ...], nlooks)
 
     # The number of looks must be at least 1 and at most the size of the input array
     # along the corresponding axis.

--- a/src/tophu/multiscale.py
+++ b/src/tophu/multiscale.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import warnings
-from typing import Optional, Tuple
 
 import dask.array as da
 import numpy as np
@@ -20,7 +21,7 @@ __all__ = [
 
 def lowpass_filter_and_multilook(
     arr: da.Array,
-    downsample_factor: Tuple[int, int],
+    downsample_factor: tuple[int, int],
     *,
     shape_factor: float = 1.5,
     overhang: float = 0.5,
@@ -204,14 +205,14 @@ def coarse_unwrap(
     coherence: da.Array,
     nlooks: float,
     unwrap: UnwrapCallback,
-    downsample_factor: Tuple[int, int],
+    downsample_factor: tuple[int, int],
     *,
     do_lowpass_filter: bool = True,
     shape_factor: float = 1.5,
     overhang: float = 0.5,
     ripple: float = 0.01,
     attenuation: float = 40.0,
-) -> Tuple[da.Array, da.Array]:
+) -> tuple[da.Array, da.Array]:
     """
     Estimate coarse unwrapped phase by unwrapping a downsampled interferogram.
 
@@ -429,14 +430,14 @@ def _multiscale_unwrap(
     coherence: da.Array,
     nlooks: float,
     unwrap: UnwrapCallback,
-    downsample_factor: Tuple[int, int],
+    downsample_factor: tuple[int, int],
     *,
     do_lowpass_filter: bool = True,
     shape_factor: float = 1.5,
     overhang: float = 0.5,
     ripple: float = 0.01,
     attenuation: float = 40.0,
-) -> Tuple[da.Array, da.Array]:
+) -> tuple[da.Array, da.Array]:
     """
     Perform 2-D phase unwrapping using a multi-resolution approach.
 
@@ -557,10 +558,10 @@ def _multiscale_unwrap(
 
 
 def get_tile_dims(
-    shape: Tuple[int, ...],
-    ntiles: Tuple[int, ...],
-    snap_to: Optional[Tuple[int, ...]] = None,
-) -> Tuple[int, ...]:
+    shape: tuple[int, ...],
+    ntiles: tuple[int, ...],
+    snap_to: tuple[int, ...] | None = None,
+) -> tuple[int, ...]:
     """
     Get tile dimensions of an array partitioned into tiles.
 
@@ -622,8 +623,8 @@ def multiscale_unwrap(
     coherence: DatasetReader,
     nlooks: float,
     unwrap: UnwrapCallback,
-    downsample_factor: Tuple[int, int],
-    ntiles: Tuple[int, int],
+    downsample_factor: tuple[int, int],
+    ntiles: tuple[int, int],
     *,
     do_lowpass_filter: bool = True,
     shape_factor: float = 1.5,

--- a/src/tophu/tile.py
+++ b/src/tophu/tile.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import itertools
-from typing import Iterable, Iterator, Optional, SupportsInt, Tuple, Union
+from collections.abc import Iterable, Iterator
 
 import numpy as np
 
@@ -8,10 +10,6 @@ from . import util
 __all__ = [
     "TiledPartition",
 ]
-
-
-IntOrInts = Union[SupportsInt, Iterable[SupportsInt]]
-NDSlice = Tuple[slice, ...]
 
 
 class TiledPartition:
@@ -31,10 +29,10 @@ class TiledPartition:
 
     def __init__(
         self,
-        shape: IntOrInts,
-        ntiles: IntOrInts,
-        overlap: Optional[IntOrInts] = None,
-        snap_to: Optional[IntOrInts] = None,
+        shape: int | Iterable[int],
+        ntiles: int | Iterable[int],
+        overlap: int | Iterable[int] | None = None,
+        snap_to: int | Iterable[int] | None = None,
     ):
         """
         Construct a new `TiledPartition` object.
@@ -111,12 +109,12 @@ class TiledPartition:
         self._tiledims = tiledims
 
     @property
-    def ntiles(self) -> Tuple[int, ...]:
+    def ntiles(self) -> tuple[int, ...]:
         """tuple of int : Number of tiles along each array axis."""
         return self._ntiles
 
     @property
-    def tiledims(self) -> Tuple[int, ...]:
+    def tiledims(self) -> tuple[int, ...]:
         """
         tuple of int : Shape of a typical tile. The last tile along each axis may be
         smaller.
@@ -124,7 +122,7 @@ class TiledPartition:
         return tuple(self._tiledims)
 
     @property
-    def strides(self) -> Tuple[int, ...]:
+    def strides(self) -> tuple[int, ...]:
         """
         tuple of int : Step size between the start of adjacent tiles along each
         axis.
@@ -132,11 +130,11 @@ class TiledPartition:
         return tuple(self._strides)
 
     @property
-    def overlap(self) -> Tuple[int, ...]:
+    def overlap(self) -> tuple[int, ...]:
         """tuple of int : Overlap between adjacent tiles along each axis."""
         return tuple(self._tiledims - self._strides)
 
-    def __getitem__(self, index: IntOrInts) -> NDSlice:
+    def __getitem__(self, index: int | Iterable[int]) -> tuple[slice, ...]:
         """
         Access a tile.
 
@@ -171,7 +169,7 @@ class TiledPartition:
 
         return tuple([slice(a, b) for (a, b) in zip(start, stop)])
 
-    def __iter__(self) -> Iterator[NDSlice]:
+    def __iter__(self) -> Iterator[tuple[slice, ...]]:
         """
         Iterate over tiles in arbitrary order.
 

--- a/src/tophu/unwrap.py
+++ b/src/tophu/unwrap.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import dataclasses
 import warnings
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Literal, Optional, Protocol, Tuple, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 import isce3
 import numpy as np
@@ -34,7 +36,7 @@ class UnwrapCallback(Protocol):
         igram: NDArray[np.complexfloating],
         corrcoef: NDArray[np.floating],
         nlooks: float,
-    ) -> Tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
+    ) -> tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
         """
         Perform two-dimensional phase unwrapping.
 
@@ -69,7 +71,7 @@ class SnaphuUnwrap(UnwrapCallback):
     cost: str
     """str : Statistical cost mode."""
 
-    cost_params: Optional[isce3.unwrap.snaphu.CostParams]
+    cost_params: isce3.unwrap.snaphu.CostParams | None
     """
     isce3.unwrap.snaphu.CostParams or None : Configuration parameters for the
     specified cost mode.
@@ -81,7 +83,7 @@ class SnaphuUnwrap(UnwrapCallback):
     def __init__(
         self,
         cost: Literal["topo", "defo", "smooth", "p-norm"] = "smooth",
-        cost_params: Optional[isce3.unwrap.snaphu.CostParams] = None,
+        cost_params: isce3.unwrap.snaphu.CostParams | None = None,
         init_method: Literal["mst", "mcf"] = "mcf",
     ):
         """
@@ -110,7 +112,7 @@ class SnaphuUnwrap(UnwrapCallback):
         igram: NDArray[np.complexfloating],
         corrcoef: NDArray[np.floating],
         nlooks: float,
-    ) -> Tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
+    ) -> tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
         # Convert input arrays to GDAL rasters with the expected datatypes.
         igram_data = np.asanyarray(igram, dtype=np.complex64)
         igram = isce3.io.gdal.Raster(igram_data)
@@ -394,7 +396,7 @@ class ICUUnwrap(UnwrapCallback):
         igram: NDArray[np.complexfloating],
         corrcoef: NDArray[np.floating],
         nlooks: float,
-    ) -> Tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
+    ) -> tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
         # Configure ICU to unwrap the interferogram as a single tile (no bootstrapping).
         icu = isce3.unwrap.ICU(
             buffer_lines=len(igram),
@@ -488,7 +490,7 @@ class PhassUnwrap(UnwrapCallback):
         igram: NDArray[np.complexfloating],
         corrcoef: NDArray[np.floating],
         nlooks: float,
-    ) -> Tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
+    ) -> tuple[NDArray[np.floating], NDArray[np.unsignedinteger]]:
         # Configure ICU to unwrap the interferogram as a single tile (no bootstrapping).
         phass = isce3.unwrap.Phass(
             correlation_threshold=self.coherence_thresh,

--- a/src/tophu/upsample.py
+++ b/src/tophu/upsample.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import itertools
-from typing import Iterable, SupportsInt, Tuple, Union
+from collections.abc import Iterable
 
 import dask.array as da
 import numpy as np
@@ -14,10 +16,7 @@ __all__ = [
 ]
 
 
-IntOrInts = Union[SupportsInt, Iterable[SupportsInt]]
-
-
-def as_tuple_of_int(ints: IntOrInts) -> Tuple[int, ...]:
+def as_tuple_of_int(ints: int | Iterable[int]) -> tuple[int, ...]:
     """
     Convert the input to a tuple of ints.
 
@@ -38,8 +37,8 @@ def as_tuple_of_int(ints: IntOrInts) -> Tuple[int, ...]:
 
 
 def validate_upsample_output_shape(
-    in_shape: Tuple[int, ...],
-    out_shape: Tuple[int, ...],
+    in_shape: tuple[int, ...],
+    out_shape: tuple[int, ...],
 ) -> None:
     """
     Check that `out_shape` is a valid upsampled output shape.
@@ -70,7 +69,7 @@ def validate_upsample_output_shape(
         raise ValueError("output shape must be >= input data shape")
 
 
-def upsample_fft(data: ArrayLike, out_shape: IntOrInts) -> NDArray:
+def upsample_fft(data: ArrayLike, out_shape: int | Iterable[int]) -> NDArray:
     """
     Upsample using a Fast Fourier Transform (FFT)-based interpolation method.
 
@@ -183,7 +182,7 @@ def upsample_fft(data: ArrayLike, out_shape: IntOrInts) -> NDArray:
 
 def pad_to_shape(
     arr: da.Array,
-    out_shape: Tuple[int, ...],
+    out_shape: tuple[int, ...],
     mode: str = "constant",
 ) -> da.Array:
     """
@@ -223,7 +222,7 @@ def pad_to_shape(
     return da.pad(arr, list(zip(zeros, padding)), mode=mode)
 
 
-def upsample_nearest(data: da.Array, out_shape: IntOrInts) -> da.Array:
+def upsample_nearest(data: da.Array, out_shape: int | Iterable[int]) -> da.Array:
     """
     Upsample an array using nearest neighbor interpolation.
 

--- a/src/tophu/util.py
+++ b/src/tophu/util.py
@@ -1,4 +1,6 @@
-from typing import Iterable, SupportsInt, Tuple, Union
+from __future__ import annotations
+
+from collections.abc import Iterable
 
 import dask.array as da
 import numpy as np
@@ -15,10 +17,7 @@ __all__ = [
 ]
 
 
-IntOrInts = Union[SupportsInt, Iterable[SupportsInt]]
-
-
-def as_tuple_of_int(ints: IntOrInts) -> Tuple[int, ...]:
+def as_tuple_of_int(ints: int | Iterable[int]) -> tuple[int, ...]:
     """
     Convert the input to a tuple of ints.
 
@@ -85,7 +84,7 @@ def iseven(n: int) -> bool:
     return n % 2 == 0
 
 
-def map_blocks(func, *args, **kwargs) -> Union[da.Array, Tuple[da.Array, ...]]:
+def map_blocks(func, *args, **kwargs) -> da.Array | tuple[da.Array, ...]:
     """
     Map a function across all blocks of a dask array.
 

--- a/test/simulate.py
+++ b/test/simulate.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -13,7 +13,7 @@ def simulate_phase_noise(
     corrcoef: ArrayLike,
     nlooks: float,
     *,
-    seed: Optional[int] = None,
+    seed: int | None = None,
 ) -> NDArray:
     r"""Simulate multilooked interferogram phase noise samples.
 
@@ -60,7 +60,7 @@ def simulate_terrain(
     *,
     scale: float = 1000.0,
     smoothness: float = 0.8,
-    seed: Optional[int] = None,
+    seed: int | None = None,
 ) -> NDArray:
     r"""Simulate topography using the Diamond-Square algorithm.
 

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import os
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Iterator, Tuple, Union
 
 import h5py
 import numpy as np
@@ -13,12 +14,12 @@ from numpy.typing import DTypeLike
 import tophu
 
 
-def filesize(filepath: Union[str, os.PathLike]) -> int:
+def filesize(filepath: str | os.PathLike) -> int:
     """Get file size in bytes."""
     return Path(filepath).stat().st_size
 
 
-def valid_gdal_dtypes() -> Tuple[np.dtype, ...]:
+def valid_gdal_dtypes() -> tuple[np.dtype, ...]:
     return (
         np.uint8,
         np.int8,
@@ -36,9 +37,9 @@ def valid_gdal_dtypes() -> Tuple[np.dtype, ...]:
 
 
 def create_raster_dataset(
-    filepath: Union[str, os.PathLike],
+    filepath: str | os.PathLike,
     driver: str,
-    shape: Tuple[int, int],
+    shape: tuple[int, int],
     count: int,
     dtype: DTypeLike,
 ) -> None:

--- a/test/test_multiscale.py
+++ b/test/test_multiscale.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from __future__ import annotations
 
 import numpy as np
 import pytest
@@ -10,7 +10,7 @@ from tophu.unwrap import UnwrapCallback
 
 from .simulate import simulate_phase_noise, simulate_terrain
 
-UNWRAP_FUNCS: List[UnwrapCallback] = [
+UNWRAP_FUNCS: list[UnwrapCallback] = [
     # tophu.ICUUnwrap(),
     tophu.PhassUnwrap(),
     tophu.SnaphuUnwrap(),
@@ -20,7 +20,7 @@ UNWRAP_FUNCS: List[UnwrapCallback] = [
 def dummy_inputs_and_outputs(
     length: int = 128,
     width: int = 128,
-) -> Tuple[
+) -> tuple[
     NDArray[np.floating],
     NDArray[np.unsignedinteger],
     NDArray[np.complexfloating],
@@ -157,7 +157,7 @@ class TestMultiScaleUnwrap:
     @pytest.mark.parametrize("unwrap", UNWRAP_FUNCS)
     def test_multiscale_unwrap_phase_conncomps(
         self,
-        downsample_factor: Tuple[int, int],
+        downsample_factor: tuple[int, int],
         unwrap: UnwrapCallback,
     ):
         length, width = 512, 512
@@ -255,7 +255,7 @@ class TestMultiScaleUnwrap:
         assert jaccard_similarity(valid_mask, expected_mask) > 0.975
 
     @pytest.mark.parametrize("downsample_factor", [(1, 1), (1, 4), (5, 1)])
-    def test_multiscale_unwrap_single_look(self, downsample_factor: Tuple[int, int]):
+    def test_multiscale_unwrap_single_look(self, downsample_factor: tuple[int, int]):
         length, width = map(lambda d: 256 * d, downsample_factor)
 
         # Radar sensor/geometry parameters.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import multiprocessing
 import threading
 from multiprocessing.pool import ThreadPool
-from typing import Tuple
 
 import dask
 import dask.array as da
@@ -114,8 +115,8 @@ def test_iseven():
 def random_integer_array(
     low: int = 0,
     high: int = 100,
-    shape: Tuple[int, ...] = (1024, 1024),
-    chunks: Tuple[int, ...] = (128, 128),
+    shape: tuple[int, ...] = (1024, 1024),
+    chunks: tuple[int, ...] = (128, 128),
 ) -> da.Array:
     return da.random.randint(low, high, size=shape, chunks=chunks)
 


### PR DESCRIPTION
Use more modern type annotations as described in [PEP 585](https://peps.python.org/pep-0585) and [PEP 604](https://peps.python.org/pep-0604/). The syntax proposed in these PEPs for Python 3.9 and 3.10 can be enabled in Python>=3.7 using

```python
from __future__ import annotations
```

Changes include:
* Replace usage of (deprecated) `typing.Tuple` and `typing.List` with `tuple` and `list`
* Replace usage of (deprecated) `typing.Iterable` and `typing.Iterator` with the corresponding classes from `collections.abc`
* Use pipe (`|`) operator syntax to avoid usage of `typing.Optional` and `typing.Union`

I also removed some awkward custom types (`IntOrInts` and `NDSlice`) and replaced their usage in the code with their literal definitions, which have been simplified a bit by the above changes.