### PR TITLE
Add numpydoc pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,12 @@ repos:
     hooks:
       - id: mypy
 
+  - repo: https://github.com/numpy/numpydoc
+    # The latest stable release doesn't yet support pre-commit.
+    rev: "6e748efc6b90ff29ddfbc1334c2ac7197ad67858"
+    hooks:
+      - id: numpydoc-validation
+
   - repo: https://github.com/hadialqattan/pycln
     rev: "v2.2.2"
     hooks:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,20 +44,3 @@ copybutton_prompt_is_regexp = True
 napoleon_include_init_with_doc = True
 napoleon_use_admonition_for_notes = True
 napoleon_use_rtype = False
-
-# Extension configuration options: `numpydoc`.
-numpydoc_validation_checks = {
-    "all",
-    "ES01",
-    "EX01",
-    "GL01",
-    "GL08",
-    "PR01",
-    "PR09",
-    "RT02",
-    "SA01",
-    "SA04",
-    "SS02",
-    "SS05",
-    "SS06",
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,25 @@ known_first_party = ["tophu"]
 python_version = "3.8"
 ignore_missing_imports = true
 
+[tool.numpydoc_validation]
+checks = [
+    "all",
+    "ES01",
+    "EX01",
+    "GL01",
+    "GL08",
+    "PR01",
+    "PR09",
+    "RT01",
+    "RT02",
+    "SA01",
+    "SA04",
+    "SS02",
+    "SS05",
+    "SS06",
+]
+exclude = ["test"]
+
 [tool.pydocstyle]
 ignore = "D100,D102,D104,D105,D203,D204,D212,D413"
 ignore-decorators="property"

--- a/src/tophu/io.py
+++ b/src/tophu/io.py
@@ -273,7 +273,7 @@ class HDF5Dataset(DatasetReader, DatasetWriter):
         dtype : data-type
             Data-type of the array's elements. Must be convertible to a `numpy.dtype`
             object.
-        kwargs : dict
+        **kwargs : dict
             Additional dataset creation options. These keywords are ignored if a dataset
             is not created. See `h5py.Group.create_dataset()` for valid options.
         """


### PR DESCRIPTION
Previously, numpydoc validation checks were run while building the docs via Sphinx.

It seems more intuitive to run them alongside the other linters now that numpydoc supports pre-commit, and results in faster feedback with better error messages. In addition, this allows us to easily pin the numpydoc version and automatically update it via `pre-commit.ci`.

It looks like the latest release of https://github.com/numpy/numpydoc doesn't yet have a `pre-commit-hooks.yaml` file, so for now we are pinned to the most recent commit.