### PR TITLE
Remove isce3 from pypi pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ setup_requires = setuptools>=42
 install_requires =
     dask>=2022.05.1
     h5py>=3
-    isce3>=0.12
     numpy>=1.21
     rasterio>=1.3
     scipy>=1.5


### PR DESCRIPTION
Not sure if there's a benefit to having isce3 there, but the pin is preventing Tophu from being installed via git without adding `--no-deps`